### PR TITLE
Test gem configuration

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -13,7 +13,7 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     env:
-      api-dir: ./api 
+      api-dir: ./api
 
     steps:
       - uses: actions/checkout@v1
@@ -27,13 +27,10 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
 
-  #     - name: Build and test with rspec
-  #       working-directory: ./
-  #       env:
-  #         EPSAGON_BACKEND: localhost:4568/
-  #         EPSAGON_METADATA: False
-  #       run: rspec spec
-  #     - name: Install Rubocop
-  #       run: gem install rubocop
-  #     - name: Check code
-  #       run: rubocop
+      - name: Build and test with rspec
+        working-directory: ./
+        run: bundle exec rspec spec/config_spec.rb
+      # - name: Install Rubocop
+      #   run: gem install rubocop
+      # - name: Check code
+      #   run: rubocop

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ gem 'faraday', '~> 1.4'
 gem 'sinatra', '~> 2.1'
 
 gem 'aws-sdk-s3', '~> 1.93'
+
+gem 'rspec-rake'

--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,5 @@ gem 'sinatra', '~> 2.1'
 gem 'aws-sdk-s3', '~> 1.93'
 
 gem 'rspec-rake'
+
+gem 'climate_control'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end

--- a/lib/epsagon.rb
+++ b/lib/epsagon.rb
@@ -28,8 +28,8 @@ module Epsagon
     @@epsagon_config = {
       metadata_only: ENV['EPSAGON_METADATA']&.to_s&.downcase != 'false',
       debug: ENV['EPSAGON_DEBUG']&.to_s&.downcase == 'true',
-      token: ENV['EPSAGON_TOKEN'],
-      app_name: ENV['EPSAGON_APP_NAME'],
+      token: ENV['EPSAGON_TOKEN'] || '',
+      app_name: ENV['EPSAGON_APP_NAME'] || '',
       max_attribute_size: ENV['EPSAGON_MAX_ATTRIBUTE_SIZE'] || 5000,
       backend: ENV['EPSAGON_BACKEND'] || DEFAULT_BACKEND
     }

--- a/lib/epsagon.rb
+++ b/lib/epsagon.rb
@@ -18,21 +18,21 @@ Bundler.require
 
 # Epsagon tracing main entry point
 module Epsagon
-  
   DEFAULT_BACKEND = 'opentelemetry.tc.epsagon.com:443/traces'
 
-  @@epsagon_config = {
-    metadata_only: ENV['EPSAGON_METADATA']&.to_s&.downcase != 'false',
-    debug: ENV['EPSAGON_DEBUG']&.to_s&.downcase == 'true',
-    token: ENV['EPSAGON_TOKEN'],
-    app_name: ENV['EPSAGON_APP_NAME'],
-    max_attribute_size: ENV['EPSAGON_MAX_ATTRIBUTE_SIZE'] || 5000,
-    backend: ENV['EPSAGON_BACKEND'] || DEFAULT_BACKEND
-  }
+  @@epsagon_config = {}
 
   module_function
 
   def init(**args)
+    @@epsagon_config = {
+      metadata_only: ENV['EPSAGON_METADATA']&.to_s&.downcase != 'false',
+      debug: ENV['EPSAGON_DEBUG']&.to_s&.downcase == 'true',
+      token: ENV['EPSAGON_TOKEN'],
+      app_name: ENV['EPSAGON_APP_NAME'],
+      max_attribute_size: ENV['EPSAGON_MAX_ATTRIBUTE_SIZE'] || 5000,
+      backend: ENV['EPSAGON_BACKEND'] || DEFAULT_BACKEND
+    }
     @@epsagon_config.merge!(args)
     OpenTelemetry::SDK.configure
   end
@@ -45,7 +45,7 @@ module Epsagon
 
   def epsagon_confs(configurator)
     configurator.resource = OpenTelemetry::SDK::Resources::Resource.telemetry_sdk.merge(
-      OpenTelemetry::SDK::Resources::Resource.create({ 
+      OpenTelemetry::SDK::Resources::Resource.create({
         'application' => @@epsagon_config[:app_name],
         'epsagon.version' => EpsagonConstants::VERSION
       })
@@ -99,7 +99,7 @@ module SpanExtension
         [k, Util.trim_attr(v, Epsagon.get_config[:max_attribute_size])]
       }]
     end
-    
+
   end
 end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -9,34 +9,50 @@ RSpec.describe do
     let(:epsagon_debug)     { true }
     let(:epsagon_metadata)  { true }
 
-    before do
-      Epsagon.init
-    end
+    describe 'retrieves values from environment variables' do
+      context 'with set values' do
+        before do
+          Epsagon.init
+        end
 
-    around do |example|
-      ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
-                  EPSAGON_APP_NAME: epsagon_app_name,
-                  EPSAGON_DEBUG: epsagon_debug.to_s,
-                  EPSAGON_METADATA: epsagon_metadata.to_s do
-        example.run
+        around do |example|
+          ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
+            EPSAGON_APP_NAME: epsagon_app_name,
+            EPSAGON_DEBUG: epsagon_debug.to_s,
+            EPSAGON_METADATA: epsagon_metadata.to_s do
+              example.run
+          end
+        end
+
+        specify 'retrieves EPSAGON_TOKEN' do
+          expect(Epsagon.get_config[:token]).to eq epsagon_token
+        end
+
+        specify 'retrieves EPSAGON_APP_NAME' do
+          expect(Epsagon.get_config[:app_name]).to eq epsagon_app_name
+        end
+
+        specify 'retrieves EPSAGON_DEBUG' do
+          expect(Epsagon.get_config[:debug]).to eq epsagon_debug
+        end
+
+        specify 'retrieves EPSAGON_METADATA' do
+          expect(Epsagon.get_config[:metadata_only]).to eq epsagon_metadata
+        end
       end
-    end
 
-    describe 'retrieves' do
-      specify 'token from environment variable' do
-        expect(Epsagon.get_config[:token]).to eq epsagon_token
-      end
+      context 'without set environment variable' do
+        before do
+          Epsagon.init
+        end
 
-      specify 'app_name from environment variable' do
-        expect(Epsagon.get_config[:app_name]).to eq epsagon_app_name
-      end
+        it 'assigns empty string to EPSAGON_TOKEN' do
+          expect(Epsagon.get_config[:token]).to eq ''
+        end
 
-      specify 'debug from environment variable' do
-        expect(Epsagon.get_config[:debug]).to eq epsagon_debug
-      end
-
-      specify 'metadata from environment variable' do
-        expect(Epsagon.get_config[:metadata_only]).to eq epsagon_metadata
+        it 'assigns empty string to EPSAGON_APP_NAME' do
+          expect(Epsagon.get_config[:app_name]).to eq ''
+        end
       end
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -55,5 +55,37 @@ RSpec.describe do
         end
       end
     end
+
+    describe 'assigns values passed to init' do
+      context 'without any arguments' do
+        before do
+          Epsagon.init
+        end
+
+        it 'assigns empty string to token' do
+          expect(Epsagon.get_config[:token]).to eq ''
+        end
+
+        it 'assigns empty string to app name' do
+          expect(Epsagon.get_config[:app_name]).to eq ''
+        end
+
+        it 'assigns default value of "false" to debug' do
+          expect(Epsagon.get_config[:debug]).to eq false
+        end
+
+        it 'assigns default value of "true" to metadata' do
+          expect(Epsagon.get_config[:metadata_only]).to eq true
+        end
+
+        it 'assigns default value of "5000" to max attribute size' do
+          expect(Epsagon.get_config[:max_attribute_size]).to eq 5000
+        end
+
+        it 'assigns default value of "opentelemetry.tc.epsagon.com:443/traces" to backend' do
+          expect(Epsagon.get_config[:backend]).to eq 'opentelemetry.tc.epsagon.com:443/traces'
+        end
+      end
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -86,6 +86,54 @@ RSpec.describe do
           expect(Epsagon.get_config[:backend]).to eq 'opentelemetry.tc.epsagon.com:443/traces'
         end
       end
+
+      context 'with token and app_name' do
+        before do
+          Epsagon.init(token: epsagon_token, app_name: epsagon_app_name)
+        end
+
+        it 'assigns the correct token' do
+          expect(Epsagon.get_config[:token]).to eq epsagon_token
+        end
+
+        it 'assigns the correct app_name' do
+          expect(Epsagon.get_config[:app_name]).to eq epsagon_app_name
+        end
+      end
+
+      context 'with environment variable set' do
+        let(:second_epsagon_token) { 'second_token' }
+        let(:second_epsagon_app_name) { 'second_app_name' }
+
+        before do
+          Epsagon.init(token: second_epsagon_token, app_name: second_epsagon_app_name)
+        end
+
+        around do |example|
+          ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
+            EPSAGON_APP_NAME: epsagon_app_name,
+            EPSAGON_DEBUG: epsagon_debug.to_s,
+            EPSAGON_METADATA: epsagon_metadata.to_s do
+              example.run
+          end
+        end
+
+        it 'does overwrite the environment epsagon_token' do
+          expect(Epsagon.get_config[:token]).to eq second_epsagon_token
+        end
+
+        it 'does overwrite the environment epsagon_app_name' do
+          expect(Epsagon.get_config[:app_name]).to eq second_epsagon_app_name
+        end
+
+        it 'keeps the debug flag' do
+          expect(Epsagon.get_config[:debug]).to eq epsagon_debug
+        end
+
+        it 'keeps the metadata flag' do
+          expect(Epsagon.get_config[:metadata_only]).to eq epsagon_metadata
+        end
+      end
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'epsagon'
+
+RSpec.describe do
+  describe 'Configuration' do
+    let(:epsagon_token)     { 'abcd' }
+    let(:epsagon_app_name)  { 'example_app' }
+    let(:epsagon_debug)     { true }
+    let(:epsagon_metadata)  { true }
+
+    before do
+      Epsagon.init
+    end
+
+    around do |example|
+      ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
+                  EPSAGON_APP_NAME: epsagon_app_name,
+                  EPSAGON_DEBUG: epsagon_debug.to_s,
+                  EPSAGON_METADATA: epsagon_metadata.to_s do
+        example.run
+      end
+    end
+
+    describe 'retrieves' do
+      specify 'token from environment variable' do
+        expect(Epsagon.get_config[:token]).to eq epsagon_token
+      end
+
+      specify 'app_name from environment variable' do
+        expect(Epsagon.get_config[:app_name]).to eq epsagon_app_name
+      end
+
+      specify 'debug from environment variable' do
+        expect(Epsagon.get_config[:debug]).to eq epsagon_debug
+      end
+
+      specify 'metadata from environment variable' do
+        expect(Epsagon.get_config[:metadata_only]).to eq epsagon_metadata
+      end
+    end
+  end
+end

--- a/spec/epsagon_spec.rb
+++ b/spec/epsagon_spec.rb
@@ -19,21 +19,23 @@ RSpec.describe do
     let(:epsagon_token)     { 'abcd' }
     let(:epsagon_app_name)  { 'example_app' }
 
+    before do
+      Epsagon.init
+    end
+
+    around do |example|
+      ClimateControl.modify EPSAGON_TOKEN: epsagon_token, EPSAGON_APP_NAME: epsagon_app_name do
+        example.run
+      end
+    end
+
     describe 'retrieves' do
       specify 'token from environment variable' do
-        ClimateControl.modify EPSAGON_TOKEN: epsagon_token, EPSAGON_APP_NAME: epsagon_app_name do
-          Epsagon.init
-          config = Epsagon.get_config
-          expect(config[:token]).to eq epsagon_token
-        end
+        expect(Epsagon.get_config[:token]).to eq epsagon_token
       end
 
       specify 'app_name from environment variable' do
-        ClimateControl.modify EPSAGON_TOKEN: epsagon_token, EPSAGON_APP_NAME: epsagon_app_name do
-          Epsagon.init
-          config = Epsagon.get_config
-          expect(config[:app_name]).to eq epsagon_app_name
-        end
+        expect(Epsagon.get_config[:app_name]).to eq epsagon_app_name
       end
     end
   end

--- a/spec/epsagon_spec.rb
+++ b/spec/epsagon_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe do
     let(:epsagon_token)     { 'abcd' }
     let(:epsagon_app_name)  { 'example_app' }
     let(:epsagon_debug)     { true }
+    let(:epsagon_metadata)  { true }
 
     before do
       Epsagon.init
@@ -27,7 +28,8 @@ RSpec.describe do
     around do |example|
       ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
                   EPSAGON_APP_NAME: epsagon_app_name,
-                  EPSAGON_DEBUG: epsagon_debug.to_s do
+                  EPSAGON_DEBUG: epsagon_debug.to_s,
+                  EPSAGON_METADATA: epsagon_metadata.to_s do
         example.run
       end
     end
@@ -43,6 +45,10 @@ RSpec.describe do
 
       specify 'debug from environment variable' do
         expect(Epsagon.get_config[:debug]).to eq epsagon_debug
+      end
+
+      specify 'metadata from environment variable' do
+        expect(Epsagon.get_config[:metadata_only]).to eq epsagon_metadata
       end
     end
   end

--- a/spec/epsagon_spec.rb
+++ b/spec/epsagon_spec.rb
@@ -18,13 +18,16 @@ RSpec.describe do
   describe 'parameters' do
     let(:epsagon_token)     { 'abcd' }
     let(:epsagon_app_name)  { 'example_app' }
+    let(:epsagon_debug)     { true }
 
     before do
       Epsagon.init
     end
 
     around do |example|
-      ClimateControl.modify EPSAGON_TOKEN: epsagon_token, EPSAGON_APP_NAME: epsagon_app_name do
+      ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
+                  EPSAGON_APP_NAME: epsagon_app_name,
+                  EPSAGON_DEBUG: epsagon_debug.to_s do
         example.run
       end
     end
@@ -36,6 +39,10 @@ RSpec.describe do
 
       specify 'app_name from environment variable' do
         expect(Epsagon.get_config[:app_name]).to eq epsagon_app_name
+      end
+
+      specify 'debug from environment variable' do
+        expect(Epsagon.get_config[:debug]).to eq epsagon_debug
       end
     end
   end

--- a/spec/epsagon_spec.rb
+++ b/spec/epsagon_spec.rb
@@ -15,44 +15,6 @@ RSpec.describe do
     sleep 3
   end
 
-  describe 'parameters' do
-    let(:epsagon_token)     { 'abcd' }
-    let(:epsagon_app_name)  { 'example_app' }
-    let(:epsagon_debug)     { true }
-    let(:epsagon_metadata)  { true }
-
-    before do
-      Epsagon.init
-    end
-
-    around do |example|
-      ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
-                  EPSAGON_APP_NAME: epsagon_app_name,
-                  EPSAGON_DEBUG: epsagon_debug.to_s,
-                  EPSAGON_METADATA: epsagon_metadata.to_s do
-        example.run
-      end
-    end
-
-    describe 'retrieves' do
-      specify 'token from environment variable' do
-        expect(Epsagon.get_config[:token]).to eq epsagon_token
-      end
-
-      specify 'app_name from environment variable' do
-        expect(Epsagon.get_config[:app_name]).to eq epsagon_app_name
-      end
-
-      specify 'debug from environment variable' do
-        expect(Epsagon.get_config[:debug]).to eq epsagon_debug
-      end
-
-      specify 'metadata from environment variable' do
-        expect(Epsagon.get_config[:metadata_only]).to eq epsagon_metadata
-      end
-    end
-  end
-
   describe 'trace' do
     it 'gets request data correctly' do
       `curl -X POST http://localhost:4567/foo/bar -d "amir=asdasd"`

--- a/spec/epsagon_spec.rb
+++ b/spec/epsagon_spec.rb
@@ -15,6 +15,29 @@ RSpec.describe do
     sleep 3
   end
 
+  describe 'parameters' do
+    let(:epsagon_token)     { 'abcd' }
+    let(:epsagon_app_name)  { 'example_app' }
+
+    describe 'retrieves' do
+      specify 'token from environment variable' do
+        ClimateControl.modify EPSAGON_TOKEN: epsagon_token, EPSAGON_APP_NAME: epsagon_app_name do
+          Epsagon.init
+          config = Epsagon.get_config
+          expect(config[:token]).to eq epsagon_token
+        end
+      end
+
+      specify 'app_name from environment variable' do
+        ClimateControl.modify EPSAGON_TOKEN: epsagon_token, EPSAGON_APP_NAME: epsagon_app_name do
+          Epsagon.init
+          config = Epsagon.get_config
+          expect(config[:app_name]).to eq epsagon_app_name
+        end
+      end
+    end
+  end
+
   describe 'trace' do
     it 'gets request data correctly' do
       `curl -X POST http://localhost:4567/foo/bar -d "amir=asdasd"`


### PR DESCRIPTION
This PR ships with added tests to cover the Gem's configuration by the user:

- via Environment variables
- via `Epsagon.init`

It also fixes an issue where if the user does not provide `EPSAGON_TOKEN` and `EPSAGON_APP_NAME`, it does not fail with an indescriptive `ArgumentError` raised by OpenTelemetry. Now it assigns empty strings to both variables. 