### PR TITLE
Improved compatibility with other tracing libraries

### DIFF
--- a/lib/instrumentation/epsagon_rails_middleware.rb
+++ b/lib/instrumentation/epsagon_rails_middleware.rb
@@ -130,7 +130,7 @@ class EpsagonRackMiddleware
   def request_span_attributes(env:)
     request = Rack::Request.new(env)
     path, path_params = request.path.split(';')
-    request_headers = JSON.generate(Hash[*env.select { |k, _v| k.start_with? 'HTTP_' }
+    request_headers = JSON.generate(Hash[*env.select { |k, _v| k.to_s.start_with? 'HTTP_' }
       .collect { |k, v| [k.sub(/^HTTP_/, ''), v] }
       .collect { |k, v| [k.split('_').collect(&:capitalize).join('-'), v] }
       .sort

--- a/lib/instrumentation/net_http.rb
+++ b/lib/instrumentation/net_http.rb
@@ -55,6 +55,7 @@ module EpsagonNetHTTPExtension
 
   def annotate_span_with_response!(span, response)
     return unless response&.code
+    return unless span.respond_to?(:set_attribute)
 
     status_code = response.code.to_i
 


### PR DESCRIPTION
This PR ships with two fixes to ensure we can co-exist in a Rails application when a user has other tracing libraries (such as `ddtrace`) installed. 

