### PR TITLE
Add Postgres Instrumentation

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build and test with rspec
         working-directory: ./
-        run: bundle exec rspec spec/config_spec.rb
+        run: bundle exec rspec spec/config_spec.rb spec/postgres_spec.rb
       # - name: Install Rubocop
       #   run: gem install rubocop
       # - name: Check code

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -14,6 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       api-dir: ./api
+    services:
+      pg:
+        image: postgres
+        env:
+          POSTGRES_USERNAME: 'postgres'
+          POSTGRES_PASSWORD: 'postgres'
+        ports:
+           - 5432:5432
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -35,9 +35,12 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
 
-      - name: Build and test with rspec
+      - name: Run Instrumentation Tests
         working-directory: ./
-        run: bundle exec rspec spec/config_spec.rb spec/postgres_spec.rb
+        run: bundle exec rspec spec/postgres_spec.rb
+      - name: Run integration tests
+        working-directory: ./
+        run: bundle exec rspec spec/config_spec.rb
       # - name: Install Rubocop
       #   run: gem install rubocop
       # - name: Check code

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem 'opentelemetry-instrumentation-sinatra', '~> 0.11.0'
 
 gem 'pry', '~> 0.13.1'
 
-gem 'byebug'
-
 gem 'opentelemetry-exporter-otlp', '~> 0.11.0'
 
 gem 'rspec', '~> 3.10'

--- a/Gemfile
+++ b/Gemfile
@@ -42,3 +42,5 @@ gem 'rspec-rake'
 gem 'climate_control'
 
 gem "pg", "~> 1.2"
+
+gem 'pg_query'

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'opentelemetry-instrumentation-sinatra', '~> 0.11.0'
 
 gem 'pry', '~> 0.13.1'
 
+gem 'byebug'
+
 gem 'opentelemetry-exporter-otlp', '~> 0.11.0'
 
 gem 'rspec', '~> 3.10'
@@ -40,3 +42,5 @@ gem "aws-sdk-sns", "~> 1.40"
 gem 'rspec-rake'
 
 gem 'climate_control'
+
+gem "pg", "~> 1.2"

--- a/epsagon.gemspec
+++ b/epsagon.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency  'opentelemetry-instrumentation-sinatra', '~> 0.11.0'
   s.add_runtime_dependency  'opentelemetry-instrumentation-sidekiq', '~> 0.11.0'
   s.add_runtime_dependency  'opentelemetry-sdk', '~> 0.11.1'
+  s.add_runtime_dependency  'pg_query', '~> 2.0'
 end

--- a/lib/epsagon.rb
+++ b/lib/epsagon.rb
@@ -12,6 +12,7 @@ require_relative 'instrumentation/net_http'
 require_relative 'instrumentation/faraday'
 require_relative 'instrumentation/aws_sdk'
 require_relative 'instrumentation/rails'
+require_relative 'instrumentation/postgres'
 require_relative 'util'
 require_relative 'epsagon_constants'
 require_relative 'exporter_extension'
@@ -61,6 +62,7 @@ module Epsagon
     configurator.use 'EpsagonAwsSdkInstrumentation', { epsagon: @@epsagon_config }
     configurator.use 'EpsagonRailsInstrumentation', { epsagon: @@epsagon_config }
     configurator.use 'OpenTelemetry::Instrumentation::Sidekiq', { epsagon: @@epsagon_config }
+    configurator.use 'EpsagonPostgresInstrumentation', { epsagon: @@epsagon_config }
 
     if @@epsagon_config[:debug]
       configurator.add_span_processor OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(

--- a/lib/instrumentation/postgres.rb
+++ b/lib/instrumentation/postgres.rb
@@ -139,6 +139,10 @@ module PostgresExtension
     end
   end
 
+  def config
+    EpsagonPostgresInstrumentation.instance.config
+  end
+
   def tracer
     EpsagonPostgresInstrumentation.instance.tracer
   end
@@ -177,7 +181,7 @@ module PostgresExtension
     end
 
     attrs = { 'db.operation' => validated_operation(operation), 'db.postgresql.prepared_statement_name' => statement_name }
-    attrs['db.statement'] = sql
+    attrs['db.statement'] = sql if config[:epsagon][:metadata_only] == false
     attrs['db.sql.table'] = table_name(sql)
     attrs['type'] = 'sql'
     attrs.reject! { |_, v| v.nil? }
@@ -276,7 +280,10 @@ class LruCache
   end
 end
 
-
+#
+# EpsagonPostgresInstrumentation
+# Installs the Instrumentation on the PG::Connection class
+#
 class EpsagonPostgresInstrumentation < OpenTelemetry::Instrumentation::Base
   install do |_config|
     ::PG::Connection.prepend(PostgresExtension)

--- a/lib/instrumentation/postgres.rb
+++ b/lib/instrumentation/postgres.rb
@@ -183,7 +183,6 @@ module PostgresExtension
     attrs = { 'db.operation' => validated_operation(operation), 'db.postgresql.prepared_statement_name' => statement_name }
     attrs['db.statement'] = sql if config[:epsagon][:metadata_only] == false
     attrs['db.sql.table'] = table_name(sql)
-    attrs['type'] = 'sql'
     attrs.reject! { |_, v| v.nil? }
 
     [database_name, client_attributes.merge(attrs)]

--- a/lib/instrumentation/postgres.rb
+++ b/lib/instrumentation/postgres.rb
@@ -1,0 +1,225 @@
+
+module PostgresExtension
+  # A list of SQL commands, from: https://www.postgresql.org/docs/current/sql-commands.html
+  # Commands are truncated to their first word, and all duplicates
+  # are removed, This favors brevity and low-cardinality over descriptiveness.
+  SQL_COMMANDS = %w[
+    ABORT
+    ALTER
+    ANALYZE
+    BEGIN
+    CALL
+    CHECKPOINT
+    CLOSE
+    CLUSTER
+    COMMENT
+    COMMIT
+    COPY
+    CREATE
+    DEALLOCATE
+    DECLARE
+    DELETE
+    DISCARD
+    DO
+    DROP
+    END
+    EXECUTE
+    EXPLAIN
+    FETCH
+    GRANT
+    IMPORT
+    INSERT
+    LISTEN
+    LOAD
+    LOCK
+    MOVE
+    NOTIFY
+    PREPARE
+    PREPARE
+    REASSIGN
+    REFRESH
+    REINDEX
+    RELEASE
+    RESET
+    REVOKE
+    ROLLBACK
+    SAVEPOINT
+    SECURITY
+    SELECT
+    SELECT
+    SET
+    SHOW
+    START
+    TRUNCATE
+    UNLISTEN
+    UPDATE
+    VACUUM
+    VALUES
+  ].freeze
+
+  # From: https://github.com/newrelic/newrelic-ruby-agent/blob/9787095d4b5b2d8fcaf2fdbd964ed07c731a8b6b/lib/new_relic/agent/database/obfuscation_helpers.rb#L9-L34
+  COMPONENTS_REGEX_MAP = {
+    single_quotes: /'(?:[^']|'')*?(?:\\'.*|'(?!'))/,
+    dollar_quotes: /(\$(?!\d)[^$]*?\$).*?(?:\1|$)/,
+    uuids: /\{?(?:[0-9a-fA-F]\-*){32}\}?/,
+    numeric_literals: /-?\b(?:[0-9]+\.)?[0-9]+([eE][+-]?[0-9]+)?\b/,
+    boolean_literals: /\b(?:true|false|null)\b/i,
+    comments: /(?:#|--).*?(?=\r|\n|$)/i,
+    multi_line_comments: %r{\/\*(?:[^\/]|\/[^*])*?(?:\*\/|\/\*.*)}
+  }.freeze
+
+  POSTGRES_COMPONENTS = %i[
+    single_quotes
+    dollar_quotes
+    uuids
+    numeric_literals
+    boolean_literals
+    comments
+    multi_line_comments
+  ].freeze
+
+  UNMATCHED_PAIRS_REGEX = %r{'|\/\*|\*\/|\$(?!\?)}.freeze
+
+  # These are all alike in that they will have a SQL statement as the first parameter.
+  # That statement may possibly be parameterized, but we can still use it - the
+  # obfuscation code will just transform $1 -> $? in that case (which is fine enough).
+  EXEC_ISH_METHODS = %i[
+    exec
+    query
+    sync_exec
+    async_exec
+    exec_params
+    async_exec_params
+    sync_exec_params
+  ].freeze
+
+  # The following methods all take a statement name as the first
+  # parameter, and a SQL statement as the second - and possibly
+  # further parameters after that. We can trace them all alike.
+  PREPARE_ISH_METHODS = %i[
+    prepare
+    async_prepare
+    sync_prepare
+  ].freeze
+
+  # The following methods take a prepared statement name as their first
+  # parameter - everything after that is either potentially quite sensitive
+  # (an array of bind params) or not useful to us. We trace them all alike.
+  EXEC_PREPARED_ISH_METHODS = %i[
+    exec_prepared
+    async_exec_prepared
+    sync_exec_prepared
+  ].freeze
+
+  EXEC_ISH_METHODS.each do |method|
+    define_method method do |*args|
+      span_name, attrs = span_attrs(:query, *args)
+      tracer.in_span(span_name, attributes: attrs, kind: :client) do
+        super(*args)
+      end
+    end
+  end
+
+  def tracer
+    EpsagonPostgresInstrumentation.instance.tracer
+  end
+
+  # Rubocop is complaining about 19.31/18 for Metrics/AbcSize.
+  # But, getting that metric in line would force us over the
+  # module size limit! We can't win here unless we want to start
+  # abstracting things into a million pieces.
+  def span_attrs(kind, *args) # rubocop:disable Metrics/AbcSize
+    if kind == :query
+      operation = extract_operation(args[0])
+      sql = obfuscate_sql(args[0])
+    else
+      statement_name = args[0]
+
+      if kind == :prepare
+        sql = obfuscate_sql(args[1])
+        lru_cache[statement_name] = sql
+        operation = 'PREPARE'
+      else
+        sql = lru_cache[statement_name]
+        operation = 'EXECUTE'
+      end
+    end
+
+    attrs = { 'db.operation' => validated_operation(operation), 'db.postgresql.prepared_statement_name' => statement_name }
+    # attrs['db.statement'] = sql if config[:enable_statement_attribute]
+    attrs.reject! { |_, v| v.nil? }
+
+    [span_name(operation), client_attributes.merge(attrs)]
+  end
+
+  def obfuscate_sql(sql)
+    # return sql unless config[:enable_sql_obfuscation]
+
+    # Borrowed from opentelemetry-instrumentation-mysql2
+    return 'SQL query too large to remove sensitive data ...' if sql.size > 2000
+
+    # From:
+    # https://github.com/newrelic/newrelic-ruby-agent/blob/9787095d4b5b2d8fcaf2fdbd964ed07c731a8b6b/lib/new_relic/agent/database/obfuscator.rb
+    # https://github.com/newrelic/newrelic-ruby-agent/blob/9787095d4b5b2d8fcaf2fdbd964ed07c731a8b6b/lib/new_relic/agent/database/obfuscation_helpers.rb
+    obfuscated = sql.gsub(generated_postgres_regex, '?')
+    obfuscated = 'Failed to obfuscate SQL query - quote characters remained after obfuscation' if PostgresExtension::UNMATCHED_PAIRS_REGEX.match(obfuscated)
+
+    obfuscated
+  end
+
+  def span_name(operation)
+    [validated_operation(operation), database_name].compact.join(' ')
+  end
+
+  def validated_operation(operation)
+    operation if PostgresExtension::SQL_COMMANDS.include?(operation)
+  end
+
+  def extract_operation(sql)
+    # From: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/9244a08a8d014afe26b82b91cf86e407c2599d73/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts#L35
+    sql.to_s.split[0].to_s.upcase
+  end
+
+  def generated_postgres_regex
+    @generated_postgres_regex ||= Regexp.union(PostgresExtension::POSTGRES_COMPONENTS.map { |component| PostgresExtension::COMPONENTS_REGEX_MAP[component] })
+  end
+
+  def database_name
+    conninfo_hash[:dbname]&.to_s
+  end
+
+  def client_attributes
+    attributes = {
+      'db.system' => 'postgresql',
+      'db.user' => conninfo_hash[:user]&.to_s,
+      'db.name' => database_name,
+      'net.peer.name' => conninfo_hash[:host]&.to_s
+    }
+    # attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+
+    attributes.merge(transport_attrs).reject { |_, v| v.nil? }
+  end
+
+  def transport_attrs
+    if conninfo_hash[:host]&.start_with?('/')
+      { 'net.transport' => 'Unix' }
+    else
+      {
+        'net.transport' => 'IP.TCP',
+        'net.peer.ip' => conninfo_hash[:hostaddr]&.to_s,
+        'net.peer.port' => conninfo_hash[:port]&.to_s
+      }
+    end
+  end
+end
+
+class EpsagonPostgresInstrumentation < OpenTelemetry::Instrumentation::Base
+  install do |_config|
+    puts "CALLING INSTALLATION"
+    ::PG::Connection.prepend(PostgresExtension)
+  end
+
+  present do
+    defined?(::PG)
+  end
+end

--- a/lib/instrumentation/postgres.rb
+++ b/lib/instrumentation/postgres.rb
@@ -142,6 +142,18 @@ module PostgresExtension
     EpsagonPostgresInstrumentation.instance.tracer
   end
 
+  def lru_cache
+    # When SQL is being sanitized, we know that this cache will
+    # never be more than 50 entries * 2000 characters (so, presumably
+    # 100k bytes - or 97k). When not sanitizing SQL, then this cache
+    # could grow much larger - but the small cache size should otherwise
+    # help contain memory growth. The intended use here is to cache
+    # prepared SQL statements, so that we can attach a reasonable
+    # `db.sql.statement` value to spans when those prepared statements
+    # are executed later on.
+    @lru_cache ||= LruCache.new(50)
+  end
+
   # Rubocop is complaining about 19.31/18 for Metrics/AbcSize.
   # But, getting that metric in line would force us over the
   # module size limit! We can't win here unless we want to start
@@ -149,16 +161,16 @@ module PostgresExtension
   def span_attrs(kind, *args) # rubocop:disable Metrics/AbcSize
     if kind == :query
       operation = extract_operation(args[0])
-      sql = obfuscate_sql(args[0])
+      sql = args[0]
     else
       statement_name = args[0]
 
       if kind == :prepare
-        sql = obfuscate_sql(args[1])
-        # lru_cache[statement_name] = sql
+        sql = args[1]
+        lru_cache[statement_name] = sql
         operation = 'PREPARE'
       else
-        # sql = lru_cache[statement_name]
+        sql = lru_cache[statement_name]
         operation = 'EXECUTE'
       end
     end
@@ -172,7 +184,7 @@ module PostgresExtension
   end
 
   def obfuscate_sql(sql)
-    # return sql unless config[:enable_sql_obfuscation]
+    return sql unless config[:enable_sql_obfuscation]
 
     # Borrowed from opentelemetry-instrumentation-mysql2
     return 'SQL query too large to remove sensitive data ...' if sql.size > 2000
@@ -187,7 +199,7 @@ module PostgresExtension
   end
 
   def span_name(operation)
-    p [validated_operation(operation), database_name].compact.join(' ')
+    [validated_operation(operation), database_name].compact.join(' ')
   end
 
   def validated_operation(operation)
@@ -231,6 +243,47 @@ module PostgresExtension
     end
   end
 end
+
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+# A simple LRU cache for the postgres instrumentation.
+class LruCache
+  # Rather than take a dependency on another gem, we implement a very, very basic
+  # LRU cache here. We can take advantage of the fact that Ruby hashes are ordered
+  # to always keep the recently-accessed keys at the top.
+  def initialize(size)
+    raise ArgumentError, 'Invalid size' if size < 1
+
+    @limit = size
+    @store = {}
+  end
+
+  def [](key)
+    # We need to check for the key explicitly, because `nil` is a valid hash value.
+    return unless @store.key?(key)
+
+    # Since the cache contains the item, we delete and re-insert into the hash.
+    # This guarantees that hash keys are ordered by access recency.
+    value = @store.delete(key)
+    @store[key] = value
+
+    value
+  end
+
+  def []=(key, value)
+    # We remove the value if it's already present, so that the hash keys remain ordered
+    # by access recency.
+    @store.delete(key)
+    @store[key] = value
+    @store.shift if @store.length > @limit
+  end
+end
+
 
 class EpsagonPostgresInstrumentation < OpenTelemetry::Instrumentation::Base
   install do |_config|

--- a/spec/postgres_spec.rb
+++ b/spec/postgres_spec.rb
@@ -3,7 +3,6 @@
 require 'pg'
 require 'opentelemetry/sdk'
 require_relative '../lib/instrumentation/postgres'
-require 'byebug'
 
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)

--- a/spec/postgres_spec.rb
+++ b/spec/postgres_spec.rb
@@ -3,9 +3,155 @@
 require 'pg'
 require 'opentelemetry/sdk'
 require_relative '../lib/instrumentation/postgres'
+require 'byebug'
 
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+host = ENV.fetch('TEST_POSTGRES_HOST', '127.0.0.1')
+port = ENV.fetch('TEST_POSTGRES_PORT', '5432')
+user = ENV.fetch('TEST_POSTGRES_USER', 'postgres')
+dbname = ENV.fetch('TEST_POSTGRES_DB', 'postgres')
+password = ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres')
+
+RSpec.shared_examples 'sending correct postgres spans' do
+  %i[exec query sync_exec async_exec].each do |method|
+    let(:statement) { 'SELECT * FROM Traces;' }
+    it "after request (with method: #{method})" do
+      client.send(method, statement)
+
+      expect(span.name).to eq 'postgres'
+      expect(span.attributes['db.system']).to eq 'postgresql'
+      expect(span.attributes['db.name']).to eq 'postgres'
+      expect(span.attributes['db.statement']).to eq statement
+      expect(span.attributes['db.operation']).to eq 'SELECT'
+      # expect(span.attributes['db.connection_string']).to eq 'Server=(localdb)\v11.0; Integrated Security=true;'
+      expect(span.attributes['db.user']).to eq 'postgres'
+      expect(span.attributes['db.sql.table'].downcase).to eq 'traces'
+      expect(span.attributes['net.peer.name']).to eq host.to_s
+      expect(span.attributes['net.peer.port']).to eq port.to_s
+    end
+  end
+
+  %i[exec_params async_exec_params sync_exec_params].each do |method|
+    it "after request (with method: #{method}) " do
+      client.send(method, 'SELECT $1 AS a', [1])
+
+      expect(span.name).to eq 'postgres'
+      expect(span.attributes['db.system']).to eq 'postgresql'
+      expect(span.attributes['db.name']).to eq 'postgres'
+      expect(span.attributes['db.statement']).to eq 'SELECT $1 AS a'
+      expect(span.attributes['db.operation']).to eq 'SELECT'
+      expect(span.attributes['net.peer.name']).to eq host.to_s
+      expect(span.attributes['net.peer.port']).to eq port.to_s
+    end
+  end
+
+  %i[prepare async_prepare sync_prepare].each do |method|
+    it "after preparing a statement (with method: #{method})" do
+      client.send(method, 'foo', 'SELECT $1 AS a')
+
+      expect(span.name).to eq 'postgres'
+      expect(span.attributes['db.system']).to eq 'postgresql'
+      expect(span.attributes['db.name']).to eq 'postgres'
+      expect(span.attributes['db.statement']).to eq 'SELECT $1 AS a'
+      expect(span.attributes['db.operation']).to eq 'PREPARE'
+      expect(span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo'
+      expect(span.attributes['net.peer.name']).to eq host.to_s
+      expect(span.attributes['net.peer.port']).to eq port.to_s
+    end
+  end
+
+  %i[exec_prepared async_exec_prepared sync_exec_prepared].each do |method|
+    it "after executing prepared statement (with method: #{method})" do
+      client.prepare('foo', 'SELECT $1 AS a')
+      client.send(method, 'foo', [1])
+
+      expect(last_span.name).to eq 'postgres'
+      expect(last_span.attributes['db.system']).to eq 'postgresql'
+      expect(last_span.attributes['db.name']).to eq 'postgres'
+      expect(last_span.attributes['db.operation']).to eq 'EXECUTE'
+      expect(last_span.attributes['db.statement']).to eq 'SELECT $1 AS a'
+      expect(last_span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo'
+      expect(last_span.attributes['net.peer.name']).to eq host.to_s
+      expect(last_span.attributes['net.peer.port']).to eq port.to_s
+    end
+  end
+
+  it 'only caches 50 prepared statement names' do
+    51.times { |i| client.prepare("foo#{i}", "SELECT $1 AS foo#{i}") }
+    client.exec_prepared('foo0', [1])
+
+    expect(last_span.name).to eq 'postgres'
+    expect(last_span.attributes['db.system']).to eq 'postgresql'
+    expect(last_span.attributes['db.name']).to eq 'postgres'
+    expect(last_span.attributes['db.operation']).to eq 'EXECUTE'
+    # We should have evicted the statement from the cache
+    expect(last_span.attributes['db.statement']).to be nil
+    expect(last_span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo0'
+    expect(last_span.attributes['net.peer.name']).to eq host.to_s
+    expect(last_span.attributes['net.peer.port']).to eq port.to_s
+  end
+
+  specify 'after error' do
+    expect do
+      client.exec('SELECT INVALID')
+    end.to raise_error PG::UndefinedColumn
+
+    expect(span.name).to eq 'postgres'
+    expect(span.attributes['db.system']).to eq 'postgresql'
+    expect(span.attributes['db.name']).to eq 'postgres'
+    expect(span.attributes['db.statement']).to eq 'SELECT INVALID'
+    expect(span.attributes['db.operation']).to eq 'SELECT'
+    expect(span.attributes['net.peer.name']).to eq host.to_s
+    expect(span.attributes['net.peer.port']).to eq port.to_s
+
+    expect(span.status.code).to eq(
+      OpenTelemetry::Trace::Status::ERROR
+    )
+    expect(span.events.first.name).to eq 'exception'
+    expect(span.events.first.attributes['exception.type']).to eq 'PG::UndefinedColumn'
+    expect(span.events.first.attributes['exception.message']).to_not be nil
+    expect(span.events.first.attributes['exception.stacktrace']).to_not be nil
+  end
+
+  it 'extracts statement type that begins the query' do
+    base_sql = 'SELECT 1'
+    explain = 'EXPLAIN'
+    explain_sql = "#{explain} #{base_sql}"
+    client.exec(explain_sql)
+
+    expect(span.name).to eq 'postgres'
+    expect(span.attributes['db.system']).to eq 'postgresql'
+    expect(span.attributes['db.name']).to eq 'postgres'
+    expect(span.attributes['db.statement']).to eq explain_sql
+    expect(span.attributes['db.operation']).to eq 'EXPLAIN'
+    expect(span.attributes['net.peer.name']).to eq host.to_s
+    expect(span.attributes['net.peer.port']).to eq port.to_s
+  end
+
+  it 'uses database name as span.name fallback with invalid sql' do
+    expect do
+      client.exec('DESELECT 1')
+    end.to raise_error PG::SyntaxError
+
+    expect(span.name).to eq 'postgres'
+    expect(span.attributes['db.system']).to eq 'postgresql'
+    expect(span.attributes['db.name']).to eq 'postgres'
+    expect(span.attributes['db.statement']).to eq 'DESELECT 1'
+    expect(span.attributes['db.operation']).to be nil
+    expect(span.attributes['net.peer.name']).to eq host.to_s
+    expect(span.attributes['net.peer.port']).to eq port.to_s
+
+    expect(span.status.code).to eq(
+      OpenTelemetry::Trace::Status::ERROR
+    )
+    expect(span.events.first.name).to eq 'exception'
+    expect(span.events.first.attributes['exception.type']).to eq 'PG::SyntaxError'
+    expect(span.events.first.attributes['exception.message']).to_not be nil
+    expect(span.events.first.attributes['exception.stacktrace'].nil?).to_not be nil
+  end
+end
 
 ##
 ## These tests require a running Postgres Docker container to talk to.
@@ -17,6 +163,27 @@ describe 'EpsagonPostgresInstrumentation' do
   let(:last_span)         { exporter.finished_spans.last }
   let(:instrumentation)   { EpsagonPostgresInstrumentation.instance }
   let(:config)            { {} }
+
+  let(:client) do
+    ::PG::Connection.open(
+      host: host,
+      port: port,
+      user: user,
+      dbname: dbname,
+      password: password
+    )
+  end
+
+  before(:all) do
+    client = ::PG::Connection.open(
+      host: host,
+      port: port,
+      user: user,
+      dbname: dbname,
+      password: password
+    )
+    client.exec('CREATE TABLE Traces (ID int PRIMARY KEY, title varchar(40));');
+  end
 
   before do
     instrumentation.instance_variable_set(:@installed, false)
@@ -36,198 +203,22 @@ describe 'EpsagonPostgresInstrumentation' do
     instrumentation.instance_variable_set(:@installed, false)
   end
 
+  after(:all) do
+    client = ::PG::Connection.open(
+      host: host,
+      port: port,
+      user: user,
+      dbname: dbname,
+      password: password
+    )
+    client.exec('DROP TABLE traces;')
+  end
+
   describe 'tracing' do
-    let(:client) do
-      ::PG::Connection.open(
-        host: host,
-        port: port,
-        user: user,
-        dbname: dbname,
-        password: password
-      )
-    end
-
-    let(:host) { ENV.fetch('TEST_POSTGRES_HOST', '127.0.0.1') }
-    let(:port) { ENV.fetch('TEST_POSTGRES_PORT', '5432') }
-    let(:user) { ENV.fetch('TEST_POSTGRES_USER', 'postgres') }
-    let(:dbname) { ENV.fetch('TEST_POSTGRES_DB', 'postgres') }
-    let(:password) { ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres') }
-
     it 'before request' do
       expect(exporter.finished_spans.size).to eq 0
     end
 
-    %i[exec query sync_exec async_exec].each do |method|
-      it "after request (with method: #{method})" do
-        client.send(method, 'SELECT 1')
-
-        expect(span.name).to eq 'SELECT postgres'
-        expect(span.attributes['db.system']).to eq 'postgresql'
-        expect(span.attributes['db.name']).to eq 'postgres'
-        expect(span.attributes['db.statement']).to eq 'SELECT 1'
-        expect(span.attributes['db.operation']).to eq 'SELECT'
-        expect(span.attributes['net.peer.name']).to eq host.to_s
-        expect(span.attributes['net.peer.port']).to eq port.to_s
-      end
-    end
-
-    %i[exec_params async_exec_params sync_exec_params].each do |method|
-      it "after request (with method: #{method}) " do
-        client.send(method, 'SELECT $1 AS a', [1])
-
-        expect(span.name).to eq 'SELECT postgres'
-        expect(span.attributes['db.system']).to eq 'postgresql'
-        expect(span.attributes['db.name']).to eq 'postgres'
-        expect(span.attributes['db.statement']).to eq 'SELECT $1 AS a'
-        expect(span.attributes['db.operation']).to eq 'SELECT'
-        expect(span.attributes['net.peer.name']).to eq host.to_s
-        expect(span.attributes['net.peer.port']).to eq port.to_s
-      end
-    end
-
-    %i[prepare async_prepare sync_prepare].each do |method|
-      it "after preparing a statement (with method: #{method})" do
-        client.send(method, 'foo', 'SELECT $1 AS a')
-
-        expect(span.name).to eq 'PREPARE postgres'
-        expect(span.attributes['db.system']).to eq 'postgresql'
-        expect(span.attributes['db.name']).to eq 'postgres'
-        expect(span.attributes['db.statement']).to eq 'SELECT $1 AS a'
-        expect(span.attributes['db.operation']).to eq 'PREPARE'
-        expect(span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo'
-        expect(span.attributes['net.peer.name']).to eq host.to_s
-        expect(span.attributes['net.peer.port']).to eq port.to_s
-      end
-    end
-
-    %i[exec_prepared async_exec_prepared sync_exec_prepared].each do |method|
-      it "after executing prepared statement (with method: #{method})" do
-        client.prepare('foo', 'SELECT $1 AS a')
-        client.send(method, 'foo', [1])
-
-        expect(last_span.name).to eq 'EXECUTE postgres'
-        expect(last_span.attributes['db.system']).to eq 'postgresql'
-        expect(last_span.attributes['db.name']).to eq 'postgres'
-        expect(last_span.attributes['db.operation']).to eq 'EXECUTE'
-        expect(last_span.attributes['db.statement']).to eq 'SELECT $1 AS a'
-        expect(last_span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo'
-        expect(last_span.attributes['net.peer.name']).to eq host.to_s
-        expect(last_span.attributes['net.peer.port']).to eq port.to_s
-      end
-    end
-
-    it 'only caches 50 prepared statement names' do
-      51.times { |i| client.prepare("foo#{i}", "SELECT $1 AS foo#{i}") }
-      client.exec_prepared('foo0', [1])
-
-      expect(last_span.name).to eq 'EXECUTE postgres'
-      expect(last_span.attributes['db.system']).to eq 'postgresql'
-      expect(last_span.attributes['db.name']).to eq 'postgres'
-      expect(last_span.attributes['db.operation']).to eq 'EXECUTE'
-      # We should have evicted the statement from the cache
-      expect(last_span.attributes['db.statement']).to be nil
-      expect(last_span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo0'
-      expect(last_span.attributes['net.peer.name']).to eq host.to_s
-      expect(last_span.attributes['net.peer.port']).to eq port.to_s
-    end
-
-    it 'after error' do
-      expect do
-        client.exec('SELECT INVALID')
-      end.to raise_error PG::UndefinedColumn
-
-      expect(span.name).to eq 'SELECT postgres'
-      expect(span.attributes['db.system']).to eq 'postgresql'
-      expect(span.attributes['db.name']).to eq 'postgres'
-      expect(span.attributes['db.statement']).to eq 'SELECT INVALID'
-      expect(span.attributes['db.operation']).to eq 'SELECT'
-      expect(span.attributes['net.peer.name']).to eq host.to_s
-      expect(span.attributes['net.peer.port']).to eq port.to_s
-
-      expect(span.status.code).to eq(
-        OpenTelemetry::Trace::Status::ERROR
-      )
-      expect(span.events.first.name).to eq 'exception'
-      expect(span.events.first.attributes['exception.type']).to eq 'PG::UndefinedColumn'
-      expect(span.events.first.attributes['exception.message']).to_not be nil
-      expect(span.events.first.attributes['exception.stacktrace']).to_not be nil
-    end
-
-    it 'extracts statement type that begins the query' do
-      base_sql = 'SELECT 1'
-      explain = 'EXPLAIN'
-      explain_sql = "#{explain} #{base_sql}"
-      client.exec(explain_sql)
-
-      expect(span.name).to eq 'EXPLAIN postgres'
-      expect(span.attributes['db.system']).to eq 'postgresql'
-      expect(span.attributes['db.name']).to eq 'postgres'
-      expect(span.attributes['db.statement']).to eq explain_sql
-      expect(span.attributes['db.operation']).to eq 'EXPLAIN'
-      expect(span.attributes['net.peer.name']).to eq host.to_s
-      expect(span.attributes['net.peer.port']).to eq port.to_s
-    end
-
-    it 'uses database name as span.name fallback with invalid sql' do
-      expect do
-        client.exec('DESELECT 1')
-      end.to raise_error PG::SyntaxError
-
-      expect(span.name).to eq 'postgres'
-      expect(span.attributes['db.system']).to eq 'postgresql'
-      expect(span.attributes['db.name']).to eq 'postgres'
-      expect(span.attributes['db.statement']).to eq 'DESELECT 1'
-      expect(span.attributes['db.operation']).to be nil
-      expect(span.attributes['net.peer.name']).to eq host.to_s
-      expect(span.attributes['net.peer.port']).to eq port.to_s
-
-      expect(span.status.code).to eq(
-        OpenTelemetry::Trace::Status::ERROR
-      )
-      expect(span.events.first.name).to eq 'exception'
-      expect(span.events.first.attributes['exception.type']).to eq 'PG::SyntaxError'
-      expect(span.events.first.attributes['exception.message']).to_not be nil
-      expect(span.events.first.attributes['exception.stacktrace'].nil?).to_not be nil
-    end
-
-    skip describe 'when enable_sql_obfuscation is enabled' do
-      let(:config) { { enable_sql_obfuscation: true } }
-
-      it 'obfuscates SQL parameters in db.statement' do
-        sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
-        obfuscated_sql = 'SELECT * from users where users.id = ? and users.email = ?'
-        expect do
-          client.exec(sql)
-        end.to raise_error PG::UndefinedTable
-
-        expect(span.attributes['db.system']).to eq 'postgresql'
-        expect(span.attributes['db.name']).to eq 'postgres'
-        expect(span.name).to eq 'SELECT postgres'
-        expect(span.attributes['db.statement']).to eq obfuscated_sql
-        expect(span.attributes['db.operation']).to eq 'SELECT'
-        expect(span.attributes['net.peer.name']).to eq host.to_s
-        expect(span.attributes['net.peer.port']).to eq port.to_s
-      end
-    end
-
-    skip describe 'when enable_statement_attribute is false' do
-      let(:config) { { enable_statement_attribute: false } }
-
-      it 'does not include SQL statement as db.statement attribute' do
-        sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
-        expect do
-          client.exec(sql)
-        end.to raise_error PG::UndefinedTable
-
-        expect(span.attributes['db.system']).to eq 'postgresql'
-        expect(span.attributes['db.name']).to eq 'postgres'
-        expect(span.name).to eq 'SELECT postgres'
-        expect(span.attributes['db.operation']).to eq 'SELECT'
-        expect(span.attributes['net.peer.name']).to eq host.to_s
-        expect(span.attributes['net.peer.port']).to eq port.to_s
-
-        expect(span.attributes['db.statement']).to be nil
-      end
-    end
+    it_behaves_like 'sending correct postgres spans'
   end
 end

--- a/spec/postgres_spec.rb
+++ b/spec/postgres_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'pg'
+require 'epsagon'
+require 'opentelemetry/sdk'
+
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+describe 'EpsagonPostgresInstrumentation' do
+  let(:instrumentation)   { EpsagonPostgresInstrumentation.instance }
+  let(:exporter)          { EXPORTER }
+  let(:span)              { exporter.finished_spans.first }
+  let(:last_span)         { exporter.finished_spans.last }
+  let(:epsagon_token)     { 'abcd' }
+  let(:epsagon_app_name)  { 'example_app' }
+  let(:config)            { {} }
+
+  around do |example|
+    ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
+                          EPSAGON_APP_NAME: epsagon_app_name do
+      example.run
+    end
+  end
+
+  before do
+    Epsagon.init
+    ClimateControl.modify EPSAGON_APP_NAME: epsagon_app_name do
+      OpenTelemetry::SDK.configure do |c|
+        c.add_span_processor span_processor
+      end
+    end
+    exporter.reset
+  end
+
+  after do
+    # Force re-install of instrumentation
+    instrumentation.instance_variable_set(:@installed, false)
+  end
+
+  describe 'tracing' do
+    let(:client) do
+      ::PG::Connection.open(
+        host: host,
+        port: port,
+        user: user,
+        dbname: dbname,
+        password: password
+      )
+    end
+
+    let(:host) { ENV.fetch('TEST_POSTGRES_HOST', '127.0.0.1') }
+    let(:port) { ENV.fetch('TEST_POSTGRES_PORT', '5432') }
+    let(:user) { ENV.fetch('TEST_POSTGRES_USER', 'postgres') }
+    let(:dbname) { ENV.fetch('TEST_POSTGRES_DB', 'postgres') }
+    let(:password) { ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres') }
+
+    # before do
+    #   instrumentation.install(config)
+    # end
+
+    it 'before request' do
+      expect(exporter.finished_spans.size).to eq 0
+    end
+
+    %i[exec query sync_exec async_exec].each do |method|
+      it "after request (with method: #{method})" do
+        client.send(method, 'SELECT 1')
+        expect(span.name).to eq 'SELECT postgres'
+        expect(span.attributes['db.system']).to eq 'postgresql'
+        expect(span.attributes['db.name']).to eq 'postgres'
+        expect(span.attributes['db.statement']).to eq 'SELECT 1'
+        expect(span.attributes['db.operation']).to eq 'SELECT'
+        expect(span.attributes['net.peer.name']).to eq host.to_s
+        expect(span.attributes['net.peer.port']).to eq port.to_s
+      end
+    end
+  end
+end

--- a/spec/postgres_spec.rb
+++ b/spec/postgres_spec.rb
@@ -1,35 +1,33 @@
 # frozen_string_literal: true
 
 require 'pg'
-require 'epsagon'
 require 'opentelemetry/sdk'
+require_relative '../lib/instrumentation/postgres'
 
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
+##
+## These tests require a running Postgres Docker container to talk to.
+## Run: docker run --name postgres -p 5432:5432 -e POSTGRES_USERNAME='postgres' -e POSTGRES_PASSWORD='postgres' -d postgres
+##
 describe 'EpsagonPostgresInstrumentation' do
-  let(:instrumentation)   { EpsagonPostgresInstrumentation.instance }
   let(:exporter)          { EXPORTER }
   let(:span)              { exporter.finished_spans.first }
   let(:last_span)         { exporter.finished_spans.last }
-  let(:epsagon_token)     { 'abcd' }
-  let(:epsagon_app_name)  { 'example_app' }
+  let(:instrumentation)   { EpsagonPostgresInstrumentation.instance }
   let(:config)            { {} }
 
-  around do |example|
-    ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
-                          EPSAGON_APP_NAME: epsagon_app_name do
-      example.run
-    end
-  end
-
   before do
-    Epsagon.init
-    ClimateControl.modify EPSAGON_APP_NAME: epsagon_app_name do
-      OpenTelemetry::SDK.configure do |c|
-        c.add_span_processor span_processor
-      end
+    instrumentation.instance_variable_set(:@installed, false)
+    instrumentation.instance_variable_set(:@config, nil)
+    exporter.reset
+
+    OpenTelemetry::SDK.configure do |c|
+      c.add_span_processor span_processor
     end
+
+    instrumentation.install({})
     exporter.reset
   end
 
@@ -55,10 +53,6 @@ describe 'EpsagonPostgresInstrumentation' do
     let(:dbname) { ENV.fetch('TEST_POSTGRES_DB', 'postgres') }
     let(:password) { ENV.fetch('TEST_POSTGRES_PASSWORD', 'postgres') }
 
-    # before do
-    #   instrumentation.install(config)
-    # end
-
     it 'before request' do
       expect(exporter.finished_spans.size).to eq 0
     end
@@ -66,6 +60,7 @@ describe 'EpsagonPostgresInstrumentation' do
     %i[exec query sync_exec async_exec].each do |method|
       it "after request (with method: #{method})" do
         client.send(method, 'SELECT 1')
+
         expect(span.name).to eq 'SELECT postgres'
         expect(span.attributes['db.system']).to eq 'postgresql'
         expect(span.attributes['db.name']).to eq 'postgres'
@@ -73,6 +68,165 @@ describe 'EpsagonPostgresInstrumentation' do
         expect(span.attributes['db.operation']).to eq 'SELECT'
         expect(span.attributes['net.peer.name']).to eq host.to_s
         expect(span.attributes['net.peer.port']).to eq port.to_s
+      end
+    end
+
+    %i[exec_params async_exec_params sync_exec_params].each do |method|
+      it "after request (with method: #{method}) " do
+        client.send(method, 'SELECT $1 AS a', [1])
+
+        expect(span.name).to eq 'SELECT postgres'
+        expect(span.attributes['db.system']).to eq 'postgresql'
+        expect(span.attributes['db.name']).to eq 'postgres'
+        expect(span.attributes['db.statement']).to eq 'SELECT $1 AS a'
+        expect(span.attributes['db.operation']).to eq 'SELECT'
+        expect(span.attributes['net.peer.name']).to eq host.to_s
+        expect(span.attributes['net.peer.port']).to eq port.to_s
+      end
+    end
+
+    %i[prepare async_prepare sync_prepare].each do |method|
+      it "after preparing a statement (with method: #{method})" do
+        client.send(method, 'foo', 'SELECT $1 AS a')
+
+        expect(span.name).to eq 'PREPARE postgres'
+        expect(span.attributes['db.system']).to eq 'postgresql'
+        expect(span.attributes['db.name']).to eq 'postgres'
+        expect(span.attributes['db.statement']).to eq 'SELECT $1 AS a'
+        expect(span.attributes['db.operation']).to eq 'PREPARE'
+        expect(span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo'
+        expect(span.attributes['net.peer.name']).to eq host.to_s
+        expect(span.attributes['net.peer.port']).to eq port.to_s
+      end
+    end
+
+    %i[exec_prepared async_exec_prepared sync_exec_prepared].each do |method|
+      it "after executing prepared statement (with method: #{method})" do
+        client.prepare('foo', 'SELECT $1 AS a')
+        client.send(method, 'foo', [1])
+
+        expect(last_span.name).to eq 'EXECUTE postgres'
+        expect(last_span.attributes['db.system']).to eq 'postgresql'
+        expect(last_span.attributes['db.name']).to eq 'postgres'
+        expect(last_span.attributes['db.operation']).to eq 'EXECUTE'
+        expect(last_span.attributes['db.statement']).to eq 'SELECT $1 AS a'
+        expect(last_span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo'
+        expect(last_span.attributes['net.peer.name']).to eq host.to_s
+        expect(last_span.attributes['net.peer.port']).to eq port.to_s
+      end
+    end
+
+    it 'only caches 50 prepared statement names' do
+      51.times { |i| client.prepare("foo#{i}", "SELECT $1 AS foo#{i}") }
+      client.exec_prepared('foo0', [1])
+
+      expect(last_span.name).to eq 'EXECUTE postgres'
+      expect(last_span.attributes['db.system']).to eq 'postgresql'
+      expect(last_span.attributes['db.name']).to eq 'postgres'
+      expect(last_span.attributes['db.operation']).to eq 'EXECUTE'
+      # We should have evicted the statement from the cache
+      expect(last_span.attributes['db.statement']).to be nil
+      expect(last_span.attributes['db.postgresql.prepared_statement_name']).to eq 'foo0'
+      expect(last_span.attributes['net.peer.name']).to eq host.to_s
+      expect(last_span.attributes['net.peer.port']).to eq port.to_s
+    end
+
+    it 'after error' do
+      expect do
+        client.exec('SELECT INVALID')
+      end.to raise_error PG::UndefinedColumn
+
+      expect(span.name).to eq 'SELECT postgres'
+      expect(span.attributes['db.system']).to eq 'postgresql'
+      expect(span.attributes['db.name']).to eq 'postgres'
+      expect(span.attributes['db.statement']).to eq 'SELECT INVALID'
+      expect(span.attributes['db.operation']).to eq 'SELECT'
+      expect(span.attributes['net.peer.name']).to eq host.to_s
+      expect(span.attributes['net.peer.port']).to eq port.to_s
+
+      expect(span.status.code).to eq(
+        OpenTelemetry::Trace::Status::ERROR
+      )
+      expect(span.events.first.name).to eq 'exception'
+      expect(span.events.first.attributes['exception.type']).to eq 'PG::UndefinedColumn'
+      expect(span.events.first.attributes['exception.message']).to_not be nil
+      expect(span.events.first.attributes['exception.stacktrace']).to_not be nil
+    end
+
+    it 'extracts statement type that begins the query' do
+      base_sql = 'SELECT 1'
+      explain = 'EXPLAIN'
+      explain_sql = "#{explain} #{base_sql}"
+      client.exec(explain_sql)
+
+      expect(span.name).to eq 'EXPLAIN postgres'
+      expect(span.attributes['db.system']).to eq 'postgresql'
+      expect(span.attributes['db.name']).to eq 'postgres'
+      expect(span.attributes['db.statement']).to eq explain_sql
+      expect(span.attributes['db.operation']).to eq 'EXPLAIN'
+      expect(span.attributes['net.peer.name']).to eq host.to_s
+      expect(span.attributes['net.peer.port']).to eq port.to_s
+    end
+
+    it 'uses database name as span.name fallback with invalid sql' do
+      expect do
+        client.exec('DESELECT 1')
+      end.to raise_error PG::SyntaxError
+
+      expect(span.name).to eq 'postgres'
+      expect(span.attributes['db.system']).to eq 'postgresql'
+      expect(span.attributes['db.name']).to eq 'postgres'
+      expect(span.attributes['db.statement']).to eq 'DESELECT 1'
+      expect(span.attributes['db.operation']).to be nil
+      expect(span.attributes['net.peer.name']).to eq host.to_s
+      expect(span.attributes['net.peer.port']).to eq port.to_s
+
+      expect(span.status.code).to eq(
+        OpenTelemetry::Trace::Status::ERROR
+      )
+      expect(span.events.first.name).to eq 'exception'
+      expect(span.events.first.attributes['exception.type']).to eq 'PG::SyntaxError'
+      expect(span.events.first.attributes['exception.message']).to_not be nil
+      expect(span.events.first.attributes['exception.stacktrace'].nil?).to_not be nil
+    end
+
+    skip describe 'when enable_sql_obfuscation is enabled' do
+      let(:config) { { enable_sql_obfuscation: true } }
+
+      it 'obfuscates SQL parameters in db.statement' do
+        sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+        obfuscated_sql = 'SELECT * from users where users.id = ? and users.email = ?'
+        expect do
+          client.exec(sql)
+        end.to raise_error PG::UndefinedTable
+
+        expect(span.attributes['db.system']).to eq 'postgresql'
+        expect(span.attributes['db.name']).to eq 'postgres'
+        expect(span.name).to eq 'SELECT postgres'
+        expect(span.attributes['db.statement']).to eq obfuscated_sql
+        expect(span.attributes['db.operation']).to eq 'SELECT'
+        expect(span.attributes['net.peer.name']).to eq host.to_s
+        expect(span.attributes['net.peer.port']).to eq port.to_s
+      end
+    end
+
+    skip describe 'when enable_statement_attribute is false' do
+      let(:config) { { enable_statement_attribute: false } }
+
+      it 'does not include SQL statement as db.statement attribute' do
+        sql = "SELECT * from users where users.id = 1 and users.email = 'test@test.com'"
+        expect do
+          client.exec(sql)
+        end.to raise_error PG::UndefinedTable
+
+        expect(span.attributes['db.system']).to eq 'postgresql'
+        expect(span.attributes['db.name']).to eq 'postgres'
+        expect(span.name).to eq 'SELECT postgres'
+        expect(span.attributes['db.operation']).to eq 'SELECT'
+        expect(span.attributes['net.peer.name']).to eq host.to_s
+        expect(span.attributes['net.peer.port']).to eq port.to_s
+
+        expect(span.attributes['db.statement']).to be nil
       end
     end
   end


### PR DESCRIPTION
This Pull Request ships with an initial implementation of the Postgres Instrumentation, based on the Open Telemetry Implementation.

Currently not enabled:

- Query Obfuscation
- peer_service

