### PR TITLE
Ecs metadata

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -37,7 +37,11 @@ jobs:
 
       - name: Instrumentation Test
         working-directory: ./
-        run: bundle exec rspec spec/ecs_metadata_spec.rb spec/postgres_spec.rb
+        run: bundle exec rspec spec/postgres_spec.rb
+
+      - name: Instrumentation Test ECS Metadata
+        working-directory: ./
+        run: bundle exec rspec spec/ecs_metadata_spec.rb
 
       - name: Instrumentation Test Rails
         working-directory: ./

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -37,7 +37,11 @@ jobs:
 
       - name: Instrumentation Test
         working-directory: ./
-        run: bundle exec rspec spec/rails_spec.rb spec/ecs_metadata_spec.rb spec/postgres_spec.rb
+        run: bundle exec rspec spec/ecs_metadata_spec.rb spec/postgres_spec.rb
+
+      - name: Instrumentation Test Rails
+        working-directory: ./
+        run: bundle exec rspec spec/rails_spec.rb
 
       - name: Integration Tests
         working-directory: ./

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -35,10 +35,11 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
 
-      - name: Run Instrumentation Tests
+      - name: Instrumentation Test
         working-directory: ./
-        run: bundle exec rspec spec/postgres_spec.rb
-      - name: Run integration tests
+        run: bundle exec rspec spec/rails_spec.rb spec/ecs_metadata_spec.rb spec/postgres_spec.rb
+
+      - name: Integration Tests
         working-directory: ./
         run: bundle exec rspec spec/config_spec.rb
       # - name: Install Rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -40,5 +40,5 @@ gem 'rspec-rake'
 gem 'climate_control'
 
 gem "pg", "~> 1.2"
-
 gem 'pg_query'
+gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-# gem "rails"
-
 gem 'opentelemetry-api', '~> 0.11.0'
 gem 'opentelemetry-sdk', '~> 0.11.1'
 

--- a/lib/arn_parser.rb
+++ b/lib/arn_parser.rb
@@ -1,0 +1,27 @@
+#
+# Credit: https://gist.github.com/RulerOf/b9f5dd00a9911aba8271b57d3d269d7a
+#
+class Arn
+  attr_accessor :partition, :service, :region, :account, :resource
+
+  def initialize(partition, service, region, account, resource)
+    @partition = partition
+    @service = service
+    @region = region
+    @account = account
+    @resource = resource
+  end
+
+  def self.parse(arn)
+    raise TypeError, 'ARN must be supplied as a string' unless arn.is_a?(String)
+
+    arn_components = arn.split(':', 6)
+    raise ArgumentError, 'Could not parse ARN' if arn_components.length < 6
+
+    Arn.new arn_components[1],
+            arn_components[2],
+            arn_components[3],
+            arn_components[4],
+            arn_components[5]
+  end
+end

--- a/lib/epsagon.rb
+++ b/lib/epsagon.rb
@@ -22,7 +22,7 @@ Bundler.require
 # Epsagon tracing main entry point
 module Epsagon
   DEFAULT_BACKEND = 'opentelemetry.tc.epsagon.com:443/traces'
-  DEFAULT_IGNORE_DOMAINS = ['newrelic.com']
+  DEFAULT_IGNORE_DOMAINS = ['newrelic.com'].freeze
 
   @@epsagon_config = {}
 

--- a/lib/epsagon.rb
+++ b/lib/epsagon.rb
@@ -24,12 +24,17 @@ module Epsagon
   DEFAULT_BACKEND = 'opentelemetry.tc.epsagon.com:443/traces'
   DEFAULT_IGNORE_DOMAINS = ['newrelic.com'].freeze
 
-  @@epsagon_config = {}
+  @@epsagon_config = nil
 
   module_function
 
   def init(**args)
-    @@epsagon_config = {
+    get_config.merge!(args)
+    OpenTelemetry::SDK.configure
+  end
+
+  def get_config
+    @@epsagon_config ||= {
       metadata_only: ENV['EPSAGON_METADATA']&.to_s&.downcase != 'false',
       debug: ENV['EPSAGON_DEBUG']&.to_s&.downcase == 'true',
       token: ENV['EPSAGON_TOKEN'] || '',
@@ -38,12 +43,6 @@ module Epsagon
       backend: ENV['EPSAGON_BACKEND'] || DEFAULT_BACKEND,
       ignore_domains: ENV['EPSAGON_IGNORE_DOMAINS'] || DEFAULT_IGNORE_DOMAINS
     }
-    @@epsagon_config.merge!(args)
-    OpenTelemetry::SDK.configure
-  end
-
-  def get_config
-    @@epsagon_config
   end
 
   # config opentelemetry with epsaon extensions:
@@ -51,26 +50,27 @@ module Epsagon
   def epsagon_confs(configurator)
     configurator.resource = OpenTelemetry::SDK::Resources::Resource.telemetry_sdk.merge(
       OpenTelemetry::SDK::Resources::Resource.create({
-        'application' => @@epsagon_config[:app_name],
+        'application' => get_config[:app_name],
         'epsagon.version' => EpsagonConstants::VERSION,
-        'epsagon.metadata_only' => @@epsagon_config[:metadata_only]
+        'epsagon.metadata_only' => get_config[:metadata_only]
       })
     )
-    configurator.use 'EpsagonSinatraInstrumentation', { epsagon: @@epsagon_config }
-    configurator.use 'EpsagonNetHTTPInstrumentation', { epsagon: @@epsagon_config }
-    configurator.use 'EpsagonFaradayInstrumentation', { epsagon: @@epsagon_config }
-    configurator.use 'EpsagonAwsSdkInstrumentation', { epsagon: @@epsagon_config }
-    configurator.use 'EpsagonRailsInstrumentation', { epsagon: @@epsagon_config }
-    configurator.use 'OpenTelemetry::Instrumentation::Sidekiq', { epsagon: @@epsagon_config }
-    configurator.use 'EpsagonPostgresInstrumentation', { epsagon: @@epsagon_config }
 
-    if @@epsagon_config[:debug]
+    configurator.use 'EpsagonSinatraInstrumentation', { epsagon: get_config }
+    configurator.use 'EpsagonNetHTTPInstrumentation', { epsagon: get_config }
+    configurator.use 'EpsagonFaradayInstrumentation', { epsagon: get_config }
+    configurator.use 'EpsagonAwsSdkInstrumentation', { epsagon: get_config }
+    configurator.use 'EpsagonRailsInstrumentation', { epsagon: get_config }
+    configurator.use 'OpenTelemetry::Instrumentation::Sidekiq', { epsagon: get_config }
+    configurator.use 'EpsagonPostgresInstrumentation', { epsagon: get_config }
+
+    if get_config[:debug]
       configurator.add_span_processor OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(
         OpenTelemetry::Exporter::OTLP::Exporter.new(headers: {
-                                                      'x-epsagon-token' => @@epsagon_config[:token]
+                                                      'x-epsagon-token' => get_config[:token]
                                                     },
-                                                    endpoint: @@epsagon_config[:backend],
-                                                    insecure: @@epsagon_config[:insecure] || false)
+                                                    endpoint: get_config[:backend],
+                                                    insecure: get_config[:insecure] || false)
       )
 
       configurator.add_span_processor OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(
@@ -79,10 +79,10 @@ module Epsagon
     else
       configurator.add_span_processor OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
         exporter: OpenTelemetry::Exporter::OTLP::Exporter.new(headers: {
-                                                                'x-epsagon-token' => @@epsagon_config[:token]
+                                                                'x-epsagon-token' => get_config[:token]
                                                               },
-                                                              endpoint: @@epsagon_config[:backend],
-                                                              insecure: @@epsagon_config[:insecure] || false)
+                                                              endpoint: get_config[:backend],
+                                                              insecure: get_config[:insecure] || false)
       )
     end
   end

--- a/lib/epsagon.rb
+++ b/lib/epsagon.rb
@@ -16,6 +16,7 @@ require_relative 'instrumentation/postgres'
 require_relative 'util'
 require_relative 'epsagon_constants'
 require_relative 'exporter_extension'
+require_relative 'arn_parser'
 
 Bundler.require
 
@@ -51,8 +52,16 @@ module Epsagon
 
     response = Net::HTTP.get(URI(metadata_uri))
     ecs_metadata = JSON.parse(response)
+    arn = Arn.parse(ecs_metadata['Labels']['com.amazonaws.ecs.task-arn'])
+
     {
-      'aws.ecs.container_name' => ecs_metadata['Labels']['com.amazonaws.ecs.container-name']
+      'aws.account_id' => arn.account,
+      'aws.region' => arn.region,
+      'aws.ecs.cluster' => ecs_metadata['Labels']['com.amazonaws.ecs.cluster'],
+      'aws.ecs.task_arn' => ecs_metadata['Labels']['com.amazonaws.ecs.task-arn'],
+      'aws.ecs.container_name' => ecs_metadata['Labels']['com.amazonaws.ecs.container-name'],
+      'aws.ecs.task.family' => ecs_metadata['Labels']['com.amazonaws.ecs.task-definition-family'],
+      'aws.ecs.task.revision' => ecs_metadata['Labels']['com.amazonaws.ecs.task-definition-version']
     }
   end
 

--- a/lib/instrumentation/epsagon_rails_middleware.rb
+++ b/lib/instrumentation/epsagon_rails_middleware.rb
@@ -189,7 +189,7 @@ class EpsagonRackMiddleware
   def set_attributes_after_request(http_span, _framework_span, status, headers, response)
     unless config[:epsagon][:metadata_only]
       http_span.set_attribute('http.response.headers', JSON.generate(headers))
-      http_span.set_attribute('http.response.body', response.join)
+      http_span.set_attribute('http.response.body', response.join) if response.respond_to?(:join)
     end
 
     http_span.set_attribute('http.status_code', status)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe do
     let(:epsagon_debug)     { true }
     let(:epsagon_metadata)  { true }
 
+    before do
+      Epsagon.class_variable_set(:@@epsagon_config, nil)
+    end
+
     describe 'retrieves values from environment variables' do
       context 'with set values' do
         before do

--- a/spec/ecs_metadata_spec.rb
+++ b/spec/ecs_metadata_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'epsagon'
+require 'webmock'
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+RSpec.describe 'ECS Metadata' do
+  let(:metadata_uri) { 'http://localhost:9000/metadata' }
+  let(:example_response) { File.read('./spec/support/aws_ecs_metadata_response.json') }
+
+  context 'with ECS environment variable set' do
+    config.before(:each) do
+      stub_request(:get, 'http://localhost:9000/metadata').
+        to_return(status: 200, body: example_response, headers: { 'Content-Type: application/json' })
+    end
+
+    around do |example|
+      ClimateControl.modify ECS_CONTAINER_METADATA_URI: metadata_uri do
+        example.run
+      end
+    end
+
+  end
+end

--- a/spec/ecs_metadata_spec.rb
+++ b/spec/ecs_metadata_spec.rb
@@ -1,18 +1,56 @@
 # frozen_string_literal: true
 
+require 'rails'
+require 'rack/test'
+require 'opentelemetry/sdk'
+require 'byebug'
+require 'webmock/rspec'
+require 'climate_control'
+require_relative 'test_helpers/app_config'
 require 'epsagon'
-require 'webmock'
 
-WebMock.disable_net_connect!(allow_localhost: true)
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
-RSpec.describe 'ECS Metadata' do
+default_rails_app = nil
+
+describe 'ECS Metadata' do
+  include Rack::Test::Methods
+
+  let(:epsagon_token)     { 'abcd' }
+  let(:epsagon_app_name)  { 'example_app' }
+  let(:exporter) { EXPORTER }
+  let(:spans) { exporter.finished_spans }
+  let(:span) { exporter.finished_spans.last }
+  let(:rails_app) { default_rails_app }
   let(:metadata_uri) { 'http://localhost:9000/metadata' }
   let(:example_response) { File.read('./spec/support/aws_ecs_metadata_response.json') }
 
+  # Clear captured spans
+  before do
+    exporter.reset
+    stub_request(:get, 'http://localhost:9000/metadata')
+      .to_return(status: 200, body: example_response, headers: {})
+
+    ClimateControl.modify EPSAGON_TOKEN: epsagon_token,
+                          EPSAGON_APP_NAME: epsagon_app_name do
+      OpenTelemetry::SDK.configure do |c|
+        c.add_span_processor span_processor
+      end
+      Epsagon.init
+    end
+
+    default_rails_app = AppConfig.initialize_app
+    ::Rails.application = default_rails_app
+  end
+
+  before do
+    # WebMock.disable_net_connect!(allow_localhost: true)
+  end
+
   context 'with ECS environment variable set' do
-    config.before(:each) do
-      stub_request(:get, 'http://localhost:9000/metadata').
-        to_return(status: 200, body: example_response, headers: { 'Content-Type: application/json' })
+    before(:each) do
+      get '/ok'
     end
 
     around do |example|
@@ -21,5 +59,26 @@ RSpec.describe 'ECS Metadata' do
       end
     end
 
+    describe 'span' do
+      it 'has aws.ecs.container_name' do
+        expect(span.resource.instance_values['attributes']['aws.ecs.container_name']).to eq 'nginx-curl'
+      end
+    end
+  end
+
+  context 'without ECS environment variable set' do
+    before do
+      get '/ok'
+    end
+
+    describe 'span' do
+      it 'does not have aws.ecs.container_name set' do
+        expect(span.resource.instance_values['attributes']['aws.ecs.container_name']).to eq nil
+      end
+    end
+  end
+
+  def app
+    rails_app
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+require 'rails'
+require 'rack/test'
+require 'opentelemetry/sdk'
+require 'byebug'
+require_relative '../lib/instrumentation/rails'
+require_relative 'test_helpers/app_config'
+
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+default_rails_app = nil
+
+describe 'Rails Instrumentation' do
+  include Rack::Test::Methods
+
+  # let(:instrumentation) { OpenTelemetry::Instrumentation::Rails::Instrumentation.instance }
+  let(:exporter) { EXPORTER }
+  let(:spans) { exporter.finished_spans }
+  let(:span) { exporter.finished_spans.last }
+  let(:rails_app) { default_rails_app }
+
+  # Clear captured spans
+  before do
+    exporter.reset
+
+    OpenTelemetry::SDK.configure do |c|
+      c.use 'EpsagonRailsInstrumentation', { epsagon: {} }
+      c.use 'EpsagonRailsInstrumentation', { epsagon: {} }
+      c.add_span_processor span_processor
+    end
+
+    default_rails_app = AppConfig.initialize_app
+    ::Rails.application = default_rails_app
+  end
+
+  it 'sets the span name to ControllerName#action' do
+    get '/ok'
+
+    expect(last_response.body).to eq 'actually ok'
+    expect(last_response.ok?).to eq true
+    expect(span.name).to eq 'example.org'
+    expect(span.kind).to eq :server
+    expect(span.status.ok?).to eq true
+
+    # expect(span.instrumentation_library.name).to eq 'OpenTelemetry::Instrumentation::Rack'
+    # expect(span.instrumentation_library.version).to eq OpenTelemetry::Instrumentation::Rack::VERSION
+
+    # expect(span.attributes['http.method']).to eq 'GET'
+    # expect(span.attributes['http.host']).to eq 'example.org'
+    expect(span.attributes['http.scheme']).to eq 'http'
+    # expect(span.attributes['http.target']).to eq '/ok'
+    expect(span.attributes['http.status_code']).to eq 200
+    expect(span.attributes['http.user_agent']).to eq nil
+    expect(span.attributes['http.route']).to eq nil
+  end
+
+  it 'sets the span name when the controller raises an exception' do
+    get 'internal_server_error'
+
+    expect(span.name).to eq 'example.org'
+  end
+
+  it 'does not set the span name when an exception is raised in middleware' do
+    get '/ok?raise_in_middleware'
+
+    expect(span.name).to eq 'example.org'
+  end
+
+  it 'has the correct span name' do
+    get '/ok?redirect_in_middleware'
+
+    expect(span.name).to eq 'example.org'
+  end
+
+  describe 'when the application has exceptions_app configured' do
+    let(:rails_app) { AppConfig.initialize_app(use_exceptions_app: true) }
+
+    it 'has the correct span name' do
+      get 'internal_server_error'
+
+      expect(span.name).to eq 'example.org'
+    end
+  end
+
+  describe 'when the application has enable_rails_route enabled' do
+    # before do
+    #   OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.config[:enable_recognize_route] = true
+    # end
+
+    # after do
+    #   OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.config[:enable_recognize_route] = false
+    # end
+
+    it 'sets the span name to ControllerName#action' do
+      get '/ok'
+
+      expect(last_response.body).to eq 'actually ok'
+      expect(last_response.ok?).to eq true
+      expect(span.name).to eq 'example.org'
+      expect(span.kind).to eq :server
+      expect(span.status.ok?).to eq true
+
+      # expect(span.instrumentation_library.name).to eq 'OpenTelemetry::Instrumentation::Rack'
+      # expect(span.instrumentation_library.version).to eq OpenTelemetry::Instrumentation::Rack::VERSION
+
+      # expect(span.attributes['http.method']).to eq 'GET'
+      # expect(span.attributes['http.host']).to eq 'example.org'
+      expect(span.attributes['http.scheme']).to eq 'http'
+      # expect(span.attributes['http.target']).to eq '/ok'
+      expect(span.attributes['http.status_code']).to eq 200
+      expect(span.attributes['http.user_agent']).to eq nil
+      # expect(span.attributes['http.route']).to eq '/ok(.:format)'
+    end
+  end
+
+  #
+  # Not sure if we need this test case because right now we're not installing EpsagonRackInstrumentation
+  #
+  skip describe 'when the application does not have the tracing rack middleware' do
+    let(:rails_app) { AppConfig.initialize_app(remove_rack_tracer_middleware: true) }
+
+    it 'does something' do
+      get '/ok'
+
+      expect(last_response.body).to eq 'actually ok'
+      expect(last_response.ok?).to eq true
+      expect(spans.size).to eq(0)
+    end
+  end
+
+  def app
+    rails_app
+  end
+end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
+
 require 'rails'
 require 'rack/test'
 require 'opentelemetry/sdk'
 require 'byebug'
+require 'webmock/rspec'
+require 'climate_control'
 require_relative '../lib/instrumentation/rails'
 require_relative 'test_helpers/app_config'
 
@@ -34,64 +37,7 @@ describe 'Rails Instrumentation' do
     ::Rails.application = default_rails_app
   end
 
-  it 'sets the span name to ControllerName#action' do
-    get '/ok'
-
-    expect(last_response.body).to eq 'actually ok'
-    expect(last_response.ok?).to eq true
-    expect(span.name).to eq 'example.org'
-    expect(span.kind).to eq :server
-    expect(span.status.ok?).to eq true
-
-    # expect(span.instrumentation_library.name).to eq 'OpenTelemetry::Instrumentation::Rack'
-    # expect(span.instrumentation_library.version).to eq OpenTelemetry::Instrumentation::Rack::VERSION
-
-    # expect(span.attributes['http.method']).to eq 'GET'
-    # expect(span.attributes['http.host']).to eq 'example.org'
-    expect(span.attributes['http.scheme']).to eq 'http'
-    # expect(span.attributes['http.target']).to eq '/ok'
-    expect(span.attributes['http.status_code']).to eq 200
-    expect(span.attributes['http.user_agent']).to eq nil
-    expect(span.attributes['http.route']).to eq nil
-  end
-
-  it 'sets the span name when the controller raises an exception' do
-    get 'internal_server_error'
-
-    expect(span.name).to eq 'example.org'
-  end
-
-  it 'does not set the span name when an exception is raised in middleware' do
-    get '/ok?raise_in_middleware'
-
-    expect(span.name).to eq 'example.org'
-  end
-
-  it 'has the correct span name' do
-    get '/ok?redirect_in_middleware'
-
-    expect(span.name).to eq 'example.org'
-  end
-
-  describe 'when the application has exceptions_app configured' do
-    let(:rails_app) { AppConfig.initialize_app(use_exceptions_app: true) }
-
-    it 'has the correct span name' do
-      get 'internal_server_error'
-
-      expect(span.name).to eq 'example.org'
-    end
-  end
-
-  describe 'when the application has enable_rails_route enabled' do
-    # before do
-    #   OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.config[:enable_recognize_route] = true
-    # end
-
-    # after do
-    #   OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.config[:enable_recognize_route] = false
-    # end
-
+  describe 'Span Format' do
     it 'sets the span name to ControllerName#action' do
       get '/ok'
 
@@ -110,22 +56,73 @@ describe 'Rails Instrumentation' do
       # expect(span.attributes['http.target']).to eq '/ok'
       expect(span.attributes['http.status_code']).to eq 200
       expect(span.attributes['http.user_agent']).to eq nil
-      # expect(span.attributes['http.route']).to eq '/ok(.:format)'
+      expect(span.attributes['http.route']).to eq nil
     end
-  end
 
-  #
-  # Not sure if we need this test case because right now we're not installing EpsagonRackInstrumentation
-  #
-  skip describe 'when the application does not have the tracing rack middleware' do
-    let(:rails_app) { AppConfig.initialize_app(remove_rack_tracer_middleware: true) }
+    it 'sets the span name when the controller raises an exception' do
+      get 'internal_server_error'
 
-    it 'does something' do
-      get '/ok'
+      expect(span.name).to eq 'example.org'
+    end
 
-      expect(last_response.body).to eq 'actually ok'
-      expect(last_response.ok?).to eq true
-      expect(spans.size).to eq(0)
+    it 'does not set the span name when an exception is raised in middleware' do
+      get '/ok?raise_in_middleware'
+
+      expect(span.name).to eq 'example.org'
+    end
+
+    it 'has the correct span name' do
+      get '/ok?redirect_in_middleware'
+
+      expect(span.name).to eq 'example.org'
+    end
+
+    describe 'when the application has exceptions_app configured' do
+      let(:rails_app) { AppConfig.initialize_app(use_exceptions_app: true) }
+
+      it 'has the correct span name' do
+        get 'internal_server_error'
+
+        expect(span.name).to eq 'example.org'
+      end
+    end
+
+    describe 'when the application has enable_rails_route enabled' do
+      it 'sets the span name to ControllerName#action' do
+        get '/ok'
+
+        expect(last_response.body).to eq 'actually ok'
+        expect(last_response.ok?).to eq true
+        expect(span.name).to eq 'example.org'
+        expect(span.kind).to eq :server
+        expect(span.status.ok?).to eq true
+
+        # expect(span.instrumentation_library.name).to eq 'OpenTelemetry::Instrumentation::Rack'
+        # expect(span.instrumentation_library.version).to eq OpenTelemetry::Instrumentation::Rack::VERSION
+
+        # expect(span.attributes['http.method']).to eq 'GET'
+        # expect(span.attributes['http.host']).to eq 'example.org'
+        expect(span.attributes['http.scheme']).to eq 'http'
+        # expect(span.attributes['http.target']).to eq '/ok'
+        expect(span.attributes['http.status_code']).to eq 200
+        expect(span.attributes['http.user_agent']).to eq nil
+        # expect(span.attributes['http.route']).to eq '/ok(.:format)'
+      end
+    end
+
+    #
+    # Not sure if we need this test case because right now we're not installing EpsagonRackInstrumentation
+    #
+    skip describe 'when the application does not have the tracing rack middleware' do
+      let(:rails_app) { AppConfig.initialize_app(remove_rack_tracer_middleware: true) }
+
+      it 'does something' do
+        get '/ok'
+
+        expect(last_response.body).to eq 'actually ok'
+        expect(last_response.ok?).to eq true
+        expect(spans.size).to eq(0)
+      end
     end
   end
 

--- a/spec/support/aws_ecs_metadata_response.json
+++ b/spec/support/aws_ecs_metadata_response.json
@@ -1,0 +1,31 @@
+{
+  "DockerId": "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+  "Name": "nginx-curl",
+  "DockerName": "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+  "Image": "nrdlngr/nginx-curl",
+  "ImageID": "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+  "Labels": {
+      "com.amazonaws.ecs.cluster": "default",
+      "com.amazonaws.ecs.container-name": "nginx-curl",
+      "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+      "com.amazonaws.ecs.task-definition-family": "nginx",
+      "com.amazonaws.ecs.task-definition-version": "5"
+  },
+  "DesiredStatus": "RUNNING",
+  "KnownStatus": "RUNNING",
+  "Limits": {
+      "CPU": 512,
+      "Memory": 512
+  },
+  "CreatedAt": "2018-02-01T20:55:10.554941919Z",
+  "StartedAt": "2018-02-01T20:55:11.064236631Z",
+  "Type": "NORMAL",
+  "Networks": [
+      {
+          "NetworkMode": "awsvpc",
+          "IPv4Addresses": [
+              "10.0.2.106"
+          ]
+      }
+  ]
+}

--- a/spec/test_helpers/app_config.rb
+++ b/spec/test_helpers/app_config.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+class Application < Rails::Application; end
+require 'action_controller/railtie'
+require 'test_helpers/middlewares'
+require 'test_helpers/controllers'
+require 'test_helpers/routes'
+
+module AppConfig
+  extend self
+
+  def initialize_app(use_exceptions_app: false, remove_rack_tracer_middleware: false)
+    new_app = Application.new
+    new_app.config.secret_key_base = 'secret_key_base'
+
+    # Ensure we don't see this Rails warning when testing
+    new_app.config.eager_load = false
+
+    # Prevent tests from creating log/*.log
+    new_app.config.logger = Logger.new(File::NULL)
+
+    case Rails.version
+    when /^6\.0/
+      apply_rails_6_0_configs(new_app)
+    when /^6\.1/
+      apply_rails_6_1_configs(new_app)
+    end
+
+    # remove_rack_middleware(new_app) if remove_rack_tracer_middleware
+    add_exceptions_app(new_app) if use_exceptions_app
+    add_middlewares(new_app)
+
+    new_app.initialize!
+
+    draw_routes(new_app)
+
+    new_app
+  end
+
+  private
+
+  # def remove_rack_middleware(application)
+  #   application.middleware.delete(
+  #     OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
+  #   )
+  # end
+
+  def add_exceptions_app(application)
+    application.config.exceptions_app = lambda do |env|
+      ExceptionsController.action(:show).call(env)
+    end
+  end
+
+  def add_middlewares(application)
+    application.middleware.insert_after(
+      ActionDispatch::DebugExceptions,
+      ExceptionRaisingMiddleware
+    )
+
+    application.middleware.insert_after(
+      ActionDispatch::DebugExceptions,
+      RedirectMiddleware
+    )
+  end
+
+  def apply_rails_6_0_configs(application)
+    # Required in Rails 6
+    application.config.hosts << 'example.org'
+    # Creates a lot of deprecation warnings on subsequent app initializations if not explicitly set.
+    application.config.action_view.finalize_compiled_template_methods = ActionView::Railtie::NULL_OPTION
+  end
+
+  def apply_rails_6_1_configs(application)
+    # Required in Rails 6
+    application.config.hosts << 'example.org'
+  end
+end

--- a/spec/test_helpers/controllers.rb
+++ b/spec/test_helpers/controllers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative 'controllers/example_controller'
+require_relative 'controllers/exceptions_controller'

--- a/spec/test_helpers/controllers/example_controller.rb
+++ b/spec/test_helpers/controllers/example_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+class ExampleController < ActionController::Base
+  include ::Rails.application.routes.url_helpers
+
+  def ok
+    render plain: 'actually ok'
+  end
+
+  def internal_server_error
+    raise :internal_server_error
+  end
+end

--- a/spec/test_helpers/controllers/exceptions_controller.rb
+++ b/spec/test_helpers/controllers/exceptions_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+class ExceptionsController < ActionController::Base
+  def show
+    render plain: 'oops', status: :internal_server_error
+  end
+end

--- a/spec/test_helpers/middlewares.rb
+++ b/spec/test_helpers/middlewares.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative 'middlewares/exception_raising_middleware'
+require_relative 'middlewares/redirect_middleware'

--- a/spec/test_helpers/middlewares/exception_raising_middleware.rb
+++ b/spec/test_helpers/middlewares/exception_raising_middleware.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+class ExceptionRaisingMiddleware
+  def initialize(app, _options = {})
+    @app = app
+  end
+
+  def call(env)
+    raise 'a little hell' if should_raise?(env)
+
+    @app.call(env)
+  end
+
+  private
+
+  def should_raise?(env)
+    env['PATH_INFO'] == '/exception' || env['QUERY_STRING'].include?('raise_in_middleware')
+  end
+end

--- a/spec/test_helpers/middlewares/redirect_middleware.rb
+++ b/spec/test_helpers/middlewares/redirect_middleware.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+class RedirectMiddleware
+  def initialize(app, _options = {})
+    @app = app
+  end
+
+  def call(env)
+    return [307, {}, 'Temporary Redirect'] if should_redirect?(env)
+
+    @app.call(env)
+  end
+
+  private
+
+  def should_redirect?(env)
+    env['PATH_INFO'] == '/redirection' || env['QUERY_STRING'].include?('redirect_in_middleware')
+  end
+end

--- a/spec/test_helpers/routes.rb
+++ b/spec/test_helpers/routes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+def draw_routes(rails_app)
+  rails_app.routes.draw do
+    get '/ok', to: 'example#ok'
+    get '/internal_server_error', to: 'example#internal_server_error'
+  end
+end


### PR DESCRIPTION
This PR ships with ECS Metadata extraction for Ruby projects.

It tests for the `ECS_CONTAINER_METADATA_URI` environment variable and, if present, queries the URI for json-formatted metadata.
This metadata gets added to the OTEL resource on application startup.

This PR also ships with a basic version of Rails tests as I initially intended to implement this feature on the Rails instrumentation.