### PR TITLE
Rails 5 tests

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -2,7 +2,8 @@ name: Lint and Test
 
 on:
   push:
-    branches: master
+    # branches: master
+    branches: "*"
   pull_request:
     branches: "*"
 
@@ -12,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       api-dir: ./api
+      RAILS_VERSION: ${{ matrix.rails }}
     services:
       pg:
         image: postgres
@@ -20,12 +22,18 @@ jobs:
           POSTGRES_PASSWORD: 'postgres'
         ports:
            - 5432:5432
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.7","3.0"]
+        rails: ["5.0", "5.2", "6.0", "6.1"]
 
     steps:
       - uses: actions/checkout@v1
-      - uses: ruby/setup-ruby@v1
+      - name: Install Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: ${{ matrix.ruby }}
 
       - name: Run bundle install
         working-directory: ./

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -2,11 +2,9 @@ name: Lint and Test
 
 on:
   push:
-    paths:
-    - '**'
+    branches: master
   pull_request:
-    paths:
-    - '**'
+    branches: "*"
 
 jobs:
   build:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -2,7 +2,6 @@ name: Lint and Test
 
 on:
   push:
-    # branches: master
     branches: "*"
   pull_request:
     branches: "*"
@@ -26,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.7","3.0"]
-        rails: ["5.0", "5.2", "6.0", "6.1"]
+        rails: ["5.0", "5.1", "5.2", "6.0", "6.1"]
 
     steps:
       - uses: actions/checkout@v1
@@ -56,7 +55,3 @@ jobs:
       - name: Integration Tests
         working-directory: ./
         run: bundle exec rspec spec/config_spec.rb
-      # - name: Install Rubocop
-      #   run: gem install rubocop
-      # - name: Check code
-      #   run: rubocop

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -26,6 +26,13 @@ jobs:
       matrix:
         ruby: ["2.7","3.0"]
         rails: ["5.0", "5.1", "5.2", "6.0", "6.1"]
+        exclude:
+          - ruby: "3.0"
+            rails: "5.0"
+          - ruby: "3.0"
+            rails: "5.1"
+          - ruby: "3.0"
+            rails: "5.2"
 
     steps:
       - uses: actions/checkout@v1

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,15 @@ gem 'aws-sdk-core', '~> 3.113'
 
 gem 'rack', '~> 2.2'
 
-gem 'rails', '~> 6.1'
+rails_version = ENV.fetch("RAILS_VERSION", "6.1")
+
+if rails_version == "master"
+  rails_constraint = { github: "rails/rails" }
+else
+  rails_constraint = "~> #{rails_version}.0"
+end
+
+gem "rails", rails_constraint
 
 gem 'faraday', '~> 1.4'
 

--- a/lib/epsagon.rb
+++ b/lib/epsagon.rb
@@ -26,8 +26,7 @@ Bundler.require
 module Epsagon
   DEFAULT_BACKEND = 'opentelemetry.tc.epsagon.com:443/traces'
   DEFAULT_IGNORE_DOMAINS = ['newrelic.com'].freeze
-  MUTABLE_CONF_KEYS = Set.new([:metadata_only, :max_attribute_size, :ignore_domains]) 
-
+  MUTABLE_CONF_KEYS = Set.new([:metadata_only, :max_attribute_size, :ignore_domains])
 
   @@epsagon_config = nil
 
@@ -43,8 +42,8 @@ module Epsagon
   def validate(config)
     Util.validate_value(config, :metadata_only, 'Must be a boolean') {|v| !!v == v}
     Util.validate_value(config, :debug, 'Must be a boolean') {|v| !!v == v}
-    Util.validate_value(config, :token, 'Must be a valid Epsagon token') {|v| v.is_a? String and v.size > 10}
-    Util.validate_value(config, :app_name, 'Must be a String') {|v| v.is_a? String}
+    Util.validate_value(config, :token, 'Must be a valid Epsagon token') {|v| (v.is_a? String) && (v.size > 10) }
+    Util.validate_value(config, :app_name, 'Must be a String') {|v| (v.is_a? String) && (v.size > 0) }
     Util.validate_value(config, :max_attribute_size, 'Must be an Integer') {|v| v.is_a? Integer}
     Util.validate_value(config, :ignore_domains, 'Must be iterable') {|v| v.respond_to?(:each)}
     Util.validate_value(config, :ignore_domains, 'Must be iterable') {|v| v.respond_to?(:each)}

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -46,48 +46,31 @@ RSpec.describe do
       end
 
       context 'without set environment variable' do
-        before do
-          Epsagon.init
+        it 'throws error when EPSAGON_TOKEN is missing' do
+          expect {
+            ClimateControl.modify EPSAGON_APP_NAME: epsagon_app_name do
+              Epsagon.init
+            end
+          }.to raise_error ArgumentError
         end
 
-        it 'assigns empty string to EPSAGON_TOKEN' do
-          expect(Epsagon.get_config[:token]).to eq ''
-        end
-
-        it 'assigns empty string to EPSAGON_APP_NAME' do
-          expect(Epsagon.get_config[:app_name]).to eq ''
+        it 'throws error when EPSAGON_APP_NAME is missing' do
+          expect {
+            ClimateControl.modify EPSAGON_TOKEN: epsagon_token do
+              Epsagon.init
+            end
+          }.to raise_error ArgumentError
         end
       end
     end
 
     describe 'assigns values passed to init' do
       context 'without any arguments' do
-        before do
-          Epsagon.init
-        end
 
-        it 'assigns empty string to token' do
-          expect(Epsagon.get_config[:token]).to eq ''
-        end
-
-        it 'assigns empty string to app name' do
-          expect(Epsagon.get_config[:app_name]).to eq ''
-        end
-
-        it 'assigns default value of "false" to debug' do
-          expect(Epsagon.get_config[:debug]).to eq false
-        end
-
-        it 'assigns default value of "true" to metadata' do
-          expect(Epsagon.get_config[:metadata_only]).to eq true
-        end
-
-        it 'assigns default value of "5000" to max attribute size' do
-          expect(Epsagon.get_config[:max_attribute_size]).to eq 5000
-        end
-
-        it 'assigns default value of "opentelemetry.tc.epsagon.com:443/traces" to backend' do
-          expect(Epsagon.get_config[:backend]).to eq 'opentelemetry.tc.epsagon.com:443/traces'
+        it 'raises an error' do
+          expect {
+            Epsagon.init
+          }.to raise_error
         end
       end
 

--- a/spec/ecs_metadata_spec.rb
+++ b/spec/ecs_metadata_spec.rb
@@ -11,7 +11,7 @@ require 'epsagon'
 
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
-epsagon_token = 'abcd'
+epsagon_token = 'abcdabcdabcdabcdabcd'
 epsagon_app_name = 'example_app'
 metadata_uri = 'http://localhost:9000/metadata'
 example_response = File.read('./spec/support/aws_ecs_metadata_response.json')


### PR DESCRIPTION
This PR ships with:

- Fixed tests (`config_spec.rb`)
- An updated CI Config

The CI Config now allows us to test against several Ruby versions as well as Rails versions. To enable the latter, I adjusted our GH Actions config as well as the Gemfile to install a specific Rails version if specified, otherwise defaulting to the latest one.

**NOTE:** We do not test Ruby 3.0 and Rails 5.x together as this causes some tests to fail for some reason. This requires further investigation.